### PR TITLE
특정 프로젝트와 global의 npmrc를 읽을 수 있도록 처리합니다.

### DIFF
--- a/main/background.ts
+++ b/main/background.ts
@@ -1,4 +1,6 @@
 import path from 'path'
+import os from 'os'
+import fs from 'fs'
 import { app, ipcMain } from 'electron'
 import serve from 'electron-serve'
 import { createWindow } from './helpers'
@@ -38,3 +40,29 @@ app.on('window-all-closed', () => {
 ipcMain.on('message', async (event, arg) => {
   event.reply('message', `${arg} World!`)
 })
+
+ipcMain.handle('get-home-dir', () => {
+  try {
+    return os.homedir();
+  } catch (error) {
+    return `Error: ${error.message}`;
+  }
+});
+
+ipcMain.handle('read-npmrc', async (_, targetPath: string) => {
+  try {
+    const content = fs.readFileSync(targetPath, 'utf8');
+    return { success: true, content };
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
+});
+
+ipcMain.handle('write-npmrc', async (_, targetPath: string, content: string) => {
+  try {
+    fs.writeFileSync(targetPath, content, 'utf8');
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
+});

--- a/main/preload.ts
+++ b/main/preload.ts
@@ -1,20 +1,19 @@
-import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron'
+import { contextBridge, ipcRenderer } from 'electron'
 
-const handler = {
-  send(channel: string, value: unknown) {
-    ipcRenderer.send(channel, value)
-  },
-  on(channel: string, callback: (...args: unknown[]) => void) {
-    const subscription = (_event: IpcRendererEvent, ...args: unknown[]) =>
-      callback(...args)
-    ipcRenderer.on(channel, subscription)
-
-    return () => {
-      ipcRenderer.removeListener(channel, subscription)
-    }
-  },
+const npmrcHandler = {
+  readNpmrc: (targetPath: string) => ipcRenderer.invoke('read-npmrc', targetPath),
+  writeNpmrc: (targetPath: string, content: string) => ipcRenderer.invoke('write-npmrc', targetPath, content),
 }
 
-contextBridge.exposeInMainWorld('ipc', handler)
+const apiHandler = {
+  getHomeDir: async () => ipcRenderer.invoke('get-home-dir')
+}
 
-export type IpcHandler = typeof handler
+contextBridge.exposeInMainWorld('npmrcAPI', npmrcHandler);
+
+contextBridge.exposeInMainWorld('api', apiHandler);
+
+export type NpmrcHandler = typeof npmrcHandler;
+export type ApiHandler = typeof apiHandler;
+
+

--- a/renderer/pages/home.tsx
+++ b/renderer/pages/home.tsx
@@ -1,43 +1,32 @@
-import React from 'react'
-import Head from 'next/head'
-import Link from 'next/link'
-import Image from 'next/image'
+import { useEffect, useState } from 'react'
 
 export default function HomePage() {
-  const [message, setMessage] = React.useState('No message found')
+  const [globalNpmrc, setGlobalNpmrc] = useState<string[]>([]);
+  const [projectNpmrc, setProjectNpmrc] = useState<string[]>([]);
 
-  React.useEffect(() => {
-    window.ipc.on('message', (message: string) => {
-      setMessage(message)
-    })
+  useEffect(() => {
+    const getNpmrc = async () => {
+      const homeDir = await window.api.getHomeDir();
+
+      const globalResult = await window.npmrcAPI.readNpmrc(`${homeDir}/.npmrc`);
+      const projectResult = await window.npmrcAPI.readNpmrc(`./.npmrc`);
+
+      const globalContent = globalResult.content.split('\n');
+      const projectContent = projectResult.content.split('\n');
+
+      setGlobalNpmrc(globalContent);
+      setProjectNpmrc(projectContent);
+    }
+
+    getNpmrc();
   }, [])
 
   return (
-    <React.Fragment>
-      <Head>
-        <title>Home - Nextron (basic-lang-typescript)</title>
-      </Head>
-      <div>
-        <p>
-          ⚡ Electron + Next.js ⚡ -<Link href="/next">Go to next page</Link>
-        </p>
-        <Image
-          src="/images/logo.png"
-          alt="Logo image"
-          width={256}
-          height={256}
-        />
-      </div>
-      <div>
-        <button
-          onClick={() => {
-            window.ipc.send('message', 'Hello')
-          }}
-        >
-          Test IPC
-        </button>
-        <p>{message}</p>
-      </div>
-    </React.Fragment>
+    <>
+      <div>global npmrc</div>
+      {globalNpmrc.map((npmrc) => <div>{npmrc}</div>)}
+      <div>local npmrc</div>
+      {projectNpmrc.map((npmrc) => <div>{npmrc}</div>)}
+    </>
   )
 }

--- a/renderer/preload.d.ts
+++ b/renderer/preload.d.ts
@@ -1,7 +1,8 @@
-import { IpcHandler } from '../main/preload'
+import { ApiHandler, IpcHandler, NpmrcHandler } from '../main/preload'
 
 declare global {
   interface Window {
-    ipc: IpcHandler
+    npmrcAPI: NpmrcHandler
+    api: ApiHandler
   }
 }


### PR DESCRIPTION
main/background에서 file system에 접근하여 `~/.npmrc`, `.npmrc`를 읽고, client에서 읽은 값을 렌더링 할 수 있도록 처리합니다.