### PR TITLE
nvm editor의 조회 속도 개선을 진행합니다.

### DIFF
--- a/main/background.ts
+++ b/main/background.ts
@@ -40,12 +40,26 @@ if (isProd) {
   }
 })()
 
+const cache = new Map()
+
 app.on('window-all-closed', () => {
   app.quit()
 })
 
 ipcMain.on('message', async (event, arg) => {
   event.reply('message', `${arg} World!`)
+})
+
+ipcMain.handle('set-cache', async (event, key, value) => {
+  cache.set(key, value)
+})
+
+ipcMain.handle('get-cache', async (event, key) => {
+  return cache.get(key)
+})
+
+ipcMain.handle('clear-cache', async () => {
+  cache.clear()
 })
 
 ipcMain.handle('get-current-node-version', () => {

--- a/main/preload.ts
+++ b/main/preload.ts
@@ -15,6 +15,9 @@ const nvmHandler = {
   setNodeVersion: async (version: string, isInstalled: boolean) =>
     ipcRenderer.invoke('nvm-set-version', version, isInstalled),
   getCurrentVersion: async () => ipcRenderer.invoke('get-current-node-version'),
+  getCache: async (key: string) => ipcRenderer.invoke('get-cache', key),
+  setCache: async (key: string, value: any) => ipcRenderer.invoke('set-cache', key, value),
+  clearCache: async () => ipcRenderer.invoke('clear-cache'),
 }
 
 const terminalHandler = {

--- a/renderer/components/nvm/nvm-editor.tsx
+++ b/renderer/components/nvm/nvm-editor.tsx
@@ -13,6 +13,13 @@ export function NvmEditor() {
   useEffect(() => {
     async function fetchFilteredVersions() {
       try {
+        const nvmCache = await window.nvmAPI.getCache('versions')
+
+        if (nvmCache) {
+          setVersions(nvmCache)
+          return
+        }
+
         const homeDir = await window.api.getHomeDir()
         const nvmrcPath = `${homeDir}/.nvmrc`
 
@@ -65,6 +72,8 @@ export function NvmEditor() {
             return versionToNumber(b.version) - versionToNumber(a.version)
           })
 
+        await window.nvmAPI.setCache('versions', versions)
+
         setVersions(versions)
       } catch (error) {
         console.error('버전 정보를 가져오지 못했습니다.', error)
@@ -84,12 +93,14 @@ export function NvmEditor() {
 
     await window.terminalAPI.openTerminal(`source ~/.bashrc`)
     alert(`${version} 버전이 활성화되었습니다. 변경된 버전은 새로운 터미널에서 확인할 수 있습니다.`)
+    await window.nvmAPI.clearCache()
     window.location.reload()
   }
 
   return (
     <List
-      style={{ height: '100%', overflow: 'auto' }}
+      style={{ height: '100vh', overflow: 'auto' }}
+      loading={versions.length === 0}
       itemLayout="horizontal"
       dataSource={versions}
       renderItem={(item, index) => (


### PR DESCRIPTION
## 설명

기존 nvm Editor에서 nvm ls, nvm ls-remote 커맨드에 대한 조회시간이 너무 오래걸리고, menu context가 바뀔때마다 불필요하게 다시 로드하는 문제를 수정합니다.

- Promise.all을 이용하여 .nvmrc 조회, nvm ls, nvm ls-remote를 병렬로 조회
- Map을 이용한 cache를 통해 menu context 변경시에도 캐싱데이터로 유지할 수 있도록 설정
  - 특정 버전을 적용한 경우에는 리스트의 갱신이 필요하기에 cache busting 진행