### PR TITLE
dependency 조회 기능을 추가합니다.

### DIFF
--- a/main/background.ts
+++ b/main/background.ts
@@ -7,6 +7,7 @@ import serve from 'electron-serve'
 import { createWindow } from './helpers'
 import Store from 'electron-store'
 import { detect } from 'detect-package-manager'
+import { getCachedData, setCachedData } from './cache'
 
 const isProd = process.env.NODE_ENV === 'production'
 
@@ -58,6 +59,18 @@ ipcMain.handle('store-delete', async (event, key) => {
 
 const cache = new Map()
 
+ipcMain.handle('set-cache', async (event, key, value) => {
+  cache.set(key, value)
+})
+
+ipcMain.handle('get-cache', async (event, key) => {
+  return cache.get(key)
+})
+
+ipcMain.handle('clear-cache', async () => {
+  cache.clear()
+})
+
 app.on('window-all-closed', () => {
   app.quit()
 })
@@ -102,6 +115,23 @@ ipcMain.handle('get-dependencies', async (event, projectPath) => {
       })
     })
   })
+})
+
+ipcMain.handle('get-dependencies-cache', async (event, filePath) => {
+  try {
+    return await getCachedData(filePath)
+  } catch (error) {
+    return `Error: ${error.message}`
+  }
+})
+
+ipcMain.handle('set-dependencies-cache', async (event, filePath, data, currentHash) => {
+  try {
+    await setCachedData(filePath, data, currentHash)
+    return 'Success'
+  } catch (error) {
+    return `Error: ${error.message}`
+  }
 })
 
 ipcMain.handle('get-package-info', async (event, packageName) => {
@@ -154,17 +184,6 @@ ipcMain.handle('link-to-docs', async (event, projectName) => {
       resolve(void 0)
     })
   })
-})
-ipcMain.handle('set-cache', async (event, key, value) => {
-  cache.set(key, value)
-})
-
-ipcMain.handle('get-cache', async (event, key) => {
-  return cache.get(key)
-})
-
-ipcMain.handle('clear-cache', async () => {
-  cache.clear()
 })
 
 ipcMain.handle('get-current-node-version', () => {

--- a/main/background.ts
+++ b/main/background.ts
@@ -88,11 +88,13 @@ ipcMain.handle('selectProjectPath', async () => {
   if (result.canceled) {
     return null
   }
-  const selectedPath = result.filePaths[0] // 선택된 디렉토리 경로
-  const packageJsonPath = path.join(selectedPath, 'package.json') // package.json 경로 생성
+
+  const selectedPath = result.filePaths[0]
+  const packageJsonPath = path.join(selectedPath, 'package.json')
 
   try {
     await fsAsync.access(packageJsonPath)
+
     return { path: selectedPath }
   } catch (err) {
     return { error: 'package.json이 없는 repository입니다.' }

--- a/main/background.ts
+++ b/main/background.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 import os from 'os'
 import fs from 'fs'
+import { promises as fsAsync } from 'fs'
 import { exec, spawn } from 'child_process'
 import { app, ipcMain, nativeTheme, dialog } from 'electron'
 import serve from 'electron-serve'
@@ -87,8 +88,15 @@ ipcMain.handle('selectProjectPath', async () => {
   if (result.canceled) {
     return null
   }
+  const selectedPath = result.filePaths[0] // 선택된 디렉토리 경로
+  const packageJsonPath = path.join(selectedPath, 'package.json') // package.json 경로 생성
 
-  return result.filePaths[0] // 선택된 디렉토리 경로 반환
+  try {
+    await fsAsync.access(packageJsonPath)
+    return { path: selectedPath }
+  } catch (err) {
+    return { error: 'package.json이 없는 repository입니다.' }
+  }
 })
 
 ipcMain.handle('get-dependencies', async (event, projectPath) => {

--- a/main/background.ts
+++ b/main/background.ts
@@ -53,7 +53,6 @@ ipcMain.handle('store-set', async (event, key, value) => {
 
 ipcMain.handle('store-delete', async (event, key) => {
   store.delete(key)
-  store.clear()
 })
 
 const cache = new Map()

--- a/main/background.ts
+++ b/main/background.ts
@@ -143,6 +143,18 @@ ipcMain.handle('get-package-info', async (event, packageName) => {
   })
 })
 
+ipcMain.handle('link-to-docs', async (event, projectName) => {
+  return new Promise((resolve, reject) => {
+    exec(`npm docs ${projectName}`, (error, stdout, stderr) => {
+      if (error) {
+        reject(stderr || error.message)
+        return
+      }
+
+      resolve(void 0)
+    })
+  })
+})
 ipcMain.handle('set-cache', async (event, key, value) => {
   cache.set(key, value)
 })

--- a/main/cache.ts
+++ b/main/cache.ts
@@ -1,0 +1,44 @@
+import { promises as fs } from 'fs'
+import crypto from 'crypto'
+import { detect } from 'detect-package-manager'
+
+type CacheEntry = {
+  data: any
+  lockHash: string
+}
+
+const cache = new Map<string, CacheEntry>()
+
+async function generateFileHash(filePath: string): Promise<string> {
+  try {
+    const fileContent = await fs.readFile(filePath, 'utf-8')
+    return crypto.createHash('sha256').update(fileContent).digest('hex')
+  } catch (error) {
+    throw error
+  }
+}
+
+export async function getCachedData(projectPath: string): Promise<any> {
+  const packageManager = await detect({ cwd: projectPath })
+  const lockFilePath = `${projectPath}/${PACKAGE_LOCK_MAP[packageManager]}`
+  const currentHash = await generateFileHash(lockFilePath)
+  const cachedEntry = cache.get(projectPath)
+
+  console.log({ currentHash, cachedEntry })
+
+  if (cachedEntry && cachedEntry.lockHash === currentHash) {
+    return { data: cachedEntry.data, currentHash }
+  }
+
+  return { data: null, currentHash }
+}
+
+export async function setCachedData(projectPath: string, data: any, currentHash: string) {
+  cache.set(projectPath, { data, lockHash: currentHash })
+}
+
+const PACKAGE_LOCK_MAP = {
+  npm: 'package-lock.json',
+  yarn: 'yarn.lock',
+  pnpm: 'pnpm-lock.yaml',
+}

--- a/main/preload.ts
+++ b/main/preload.ts
@@ -24,6 +24,16 @@ const terminalHandler = {
   openTerminal: async (command: string) => ipcRenderer.invoke('open-terminal', command),
 }
 
+const projectHandler = {
+  getProject: async () => ipcRenderer.invoke('selectProjectPath'),
+}
+
+const storeHandler = {
+  get: async (key: string) => ipcRenderer.invoke('store-get', key),
+  set: async (key: string, value: any) => ipcRenderer.invoke('store-set', key, value),
+  delete: async (key: string) => ipcRenderer.invoke('store-delete', key),
+}
+
 contextBridge.exposeInMainWorld('npmrcAPI', npmrcHandler)
 
 contextBridge.exposeInMainWorld('api', apiHandler)
@@ -32,7 +42,13 @@ contextBridge.exposeInMainWorld('nvmAPI', nvmHandler)
 
 contextBridge.exposeInMainWorld('terminalAPI', terminalHandler)
 
+contextBridge.exposeInMainWorld('projectAPI', projectHandler)
+
+contextBridge.exposeInMainWorld('storeAPI', storeHandler)
+
 export type NpmrcHandler = typeof npmrcHandler
 export type ApiHandler = typeof apiHandler
 export type NvmHandler = typeof nvmHandler
 export type TerminalHandler = typeof terminalHandler
+export type ProjectHandler = typeof projectHandler
+export type StoreHandler = typeof storeHandler

--- a/main/preload.ts
+++ b/main/preload.ts
@@ -26,6 +26,10 @@ const terminalHandler = {
 
 const projectHandler = {
   getProject: async () => ipcRenderer.invoke('selectProjectPath'),
+  getDependencies: async (projectPath: string) =>
+    ipcRenderer.invoke('get-dependencies', projectPath),
+  getPackageInfo: async (packageName: string) =>
+    ipcRenderer.invoke('get-package-info', packageName),
 }
 
 const storeHandler = {

--- a/main/preload.ts
+++ b/main/preload.ts
@@ -30,6 +30,7 @@ const projectHandler = {
     ipcRenderer.invoke('get-dependencies', projectPath),
   getPackageInfo: async (packageName: string) =>
     ipcRenderer.invoke('get-package-info', packageName),
+  linkToDocs: async (projectName: string) => ipcRenderer.invoke('link-to-docs', projectName),
 }
 
 const storeHandler = {

--- a/main/preload.ts
+++ b/main/preload.ts
@@ -39,6 +39,13 @@ const storeHandler = {
   delete: async (key: string) => ipcRenderer.invoke('store-delete', key),
 }
 
+const cacheHandler = {
+  getDependencies: async (filePath: string) =>
+    ipcRenderer.invoke('get-dependencies-cache', filePath),
+  setDependencies: async (filePath: string, data: any, currentHash: string) =>
+    ipcRenderer.invoke('set-dependencies-cache', filePath, data, currentHash),
+}
+
 contextBridge.exposeInMainWorld('npmrcAPI', npmrcHandler)
 
 contextBridge.exposeInMainWorld('api', apiHandler)
@@ -51,9 +58,12 @@ contextBridge.exposeInMainWorld('projectAPI', projectHandler)
 
 contextBridge.exposeInMainWorld('storeAPI', storeHandler)
 
+contextBridge.exposeInMainWorld('cacheAPI', cacheHandler)
+
 export type NpmrcHandler = typeof npmrcHandler
 export type ApiHandler = typeof apiHandler
 export type NvmHandler = typeof nvmHandler
 export type TerminalHandler = typeof terminalHandler
 export type ProjectHandler = typeof projectHandler
 export type StoreHandler = typeof storeHandler
+export type CacheHandler = typeof cacheHandler

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "electron-serve": "^1.3.0",
     "electron-store": "^8.2.0",
     "styled-components": "^6.1.14",
-    "styled-reset": "^4.5.2"
+    "styled-reset": "^4.5.2",
+    "uuid": "^11.0.5"
   },
   "devDependencies": {
     "@babel/runtime-corejs3": "^7.26.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@ant-design/cssinjs": "^1.22.1",
+    "@ant-design/icons": "^5.5.2",
     "@monaco-editor/react": "^4.6.0",
     "antd": "^5.23.0",
     "detect-package-manager": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "detect-package-manager": "^3.0.2",
     "electron-serve": "^1.3.0",
     "electron-store": "^8.2.0",
+    "next-transpile-modules": "^10.0.1",
     "styled-components": "^6.1.14",
     "styled-reset": "^4.5.2",
     "uuid": "^11.0.5"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@ant-design/cssinjs": "^1.22.1",
     "@monaco-editor/react": "^4.6.0",
     "antd": "^5.23.0",
+    "detect-package-manager": "^3.0.2",
     "electron-serve": "^1.3.0",
     "electron-store": "^8.2.0",
     "styled-components": "^6.1.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       styled-reset:
         specifier: ^4.5.2
         version: 4.5.2(styled-components@6.1.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      uuid:
+        specifier: ^11.0.5
+        version: 11.0.5
     devDependencies:
       '@babel/runtime-corejs3':
         specifier: ^7.26.0
@@ -3021,6 +3024,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@11.0.5:
+    resolution: {integrity: sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==}
+    hasBin: true
 
   verror@1.10.1:
     resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
@@ -6553,6 +6560,8 @@ snapshots:
   utf8-byte-length@1.0.5: {}
 
   util-deprecate@1.0.2: {}
+
+  uuid@11.0.5: {}
 
   verror@1.10.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@ant-design/cssinjs':
         specifier: ^1.22.1
         version: 1.22.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@ant-design/icons':
+        specifier: ^5.5.2
+        version: 5.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@monaco-editor/react':
         specifier: ^4.6.0
         version: 4.6.0(monaco-editor@0.52.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       antd:
         specifier: ^5.23.0
         version: 5.23.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      detect-package-manager:
+        specifier: ^3.0.2
+        version: 3.0.2
       electron-serve:
         specifier: ^1.3.0
         version: 1.3.0
@@ -1469,6 +1472,10 @@ packages:
 
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
+
+  detect-package-manager@3.0.2:
+    resolution: {integrity: sha512-8JFjJHutStYrfWwzfretQoyNGoZVW1Fsrp4JO9spa7h/fBfwgTMEIy4/LBzRDGsxwVPHU0q+T9YvwLDJoOApLQ==}
+    engines: {node: '>=12'}
 
   dir-compare@3.3.0:
     resolution: {integrity: sha512-J7/et3WlGUCxjdnD3HAAzQ6nsnc0WL6DD7WcwJb7c39iH1+AWfg+9OqzJNaI6PkBwBvm1mhZNL9iY/nRiZXlPg==}
@@ -4894,6 +4901,10 @@ snapshots:
 
   detect-node@2.1.0:
     optional: true
+
+  detect-package-manager@3.0.2:
+    dependencies:
+      execa: 5.1.1
 
   dir-compare@3.3.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       electron-store:
         specifier: ^8.2.0
         version: 8.2.0
+      next-transpile-modules:
+        specifier: ^10.0.1
+        version: 10.0.1
       styled-components:
         specifier: ^6.1.14
         version: 6.1.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2188,6 +2191,9 @@ packages:
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  next-transpile-modules@10.0.1:
+    resolution: {integrity: sha512-4VX/LCMofxIYAVV58UmD+kr8jQflpLWvas/BQ4Co0qWLWzVh06FoZkECkrX5eEZT6oJFqie6+kfbTA3EZCVtdQ==}
 
   next@14.2.23:
     resolution: {integrity: sha512-mjN3fE6u/tynneLiEg56XnthzuYw+kD7mCujgVqioxyPqbmiotUCGJpIZGS/VaPg3ZDT1tvWxiVyRzeqJFm/kw==}
@@ -5644,6 +5650,10 @@ snapshots:
   natural-compare@1.4.0: {}
 
   neo-async@2.6.2: {}
+
+  next-transpile-modules@10.0.1:
+    dependencies:
+      enhanced-resolve: 5.18.0
 
   next@14.2.23(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:

--- a/renderer/components/dependencies/dependencies-detail-viewer.tsx
+++ b/renderer/components/dependencies/dependencies-detail-viewer.tsx
@@ -1,7 +1,40 @@
 import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
 
 export function DependenciesDetailViewer() {
+  const [dependencies, setDependencies] = useState<{ name: string; version: string }[]>([])
   const router = useRouter()
+  const id = router.query.id
 
-  return <div>{router.query.id}</div>
+  useEffect(() => {
+    const fetchAndSetDependencies = async () => {
+      const projectPaths: {
+        id: string
+        path: string
+      }[] = await window.storeAPI.get('projectPath')
+
+      const currentProjectPath = projectPaths.find((projectPath) => projectPath.id === id)
+
+      if (!currentProjectPath) {
+        return
+      }
+
+      const dependencies = await window.projectAPI.getDependencies(currentProjectPath.path)
+
+      setDependencies(dependencies)
+    }
+
+    fetchAndSetDependencies()
+  }, [])
+
+  return (
+    <div>
+      {dependencies.map((dependency) => (
+        <div key={dependency.name}>
+          <span>{dependency.name}</span>
+          <span>{dependency.version}</span>
+        </div>
+      ))}
+    </div>
+  )
 }

--- a/renderer/components/dependencies/dependencies-detail-viewer.tsx
+++ b/renderer/components/dependencies/dependencies-detail-viewer.tsx
@@ -1,5 +1,7 @@
+import { List } from 'antd'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
+import { DependencyDetailInfo } from './dependency-detail-info'
 
 export function DependenciesDetailViewer() {
   const [dependencies, setDependencies] = useState<{ name: string; version: string }[]>([])
@@ -28,13 +30,23 @@ export function DependenciesDetailViewer() {
   }, [])
 
   return (
-    <div>
-      {dependencies.map((dependency) => (
-        <div key={dependency.name}>
-          <span>{dependency.name}</span>
-          <span>{dependency.version}</span>
-        </div>
-      ))}
-    </div>
+    <List
+      style={{ height: '100vh', overflow: 'auto' }}
+      itemLayout="horizontal"
+      dataSource={dependencies}
+      renderItem={(projectPath, idx) => (
+        <>
+          <List.Item style={{ display: 'flex', alignItems: 'center', padding: '20px' }}>
+            <List.Item.Meta title={projectPath.name} description={projectPath.version} />
+            {idx === 0 ? (
+              <DependencyDetailInfo
+                dependencyName={projectPath.name}
+                dependencyVersion={projectPath.version}
+              />
+            ) : null}
+          </List.Item>
+        </>
+      )}
+    />
   )
 }

--- a/renderer/components/dependencies/dependencies-detail-viewer.tsx
+++ b/renderer/components/dependencies/dependencies-detail-viewer.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 import { DependencyItem } from './dependency-item'
 import { DependencyHeader } from './header'
+import { BackButton } from '../shared/back-button'
 
 export function DependenciesDetailViewer() {
   const [dependencies, setDependencies] = useState<{ name: string; version: string }[]>([])
@@ -44,7 +45,7 @@ export function DependenciesDetailViewer() {
 
   return (
     <>
-      <DependencyHeader title={projectPath} />
+      <DependencyHeader title={projectPath} left={<BackButton />} />
       <List
         style={{ height: '100vh', overflow: 'auto' }}
         itemLayout="horizontal"

--- a/renderer/components/dependencies/dependencies-detail-viewer.tsx
+++ b/renderer/components/dependencies/dependencies-detail-viewer.tsx
@@ -1,7 +1,7 @@
 import { List } from 'antd'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
-import { DependencyDetailInfo } from './dependency-detail-info'
+import { DependencyItem } from './dependency-item'
 
 export function DependenciesDetailViewer() {
   const [dependencies, setDependencies] = useState<{ name: string; version: string }[]>([])
@@ -34,18 +34,12 @@ export function DependenciesDetailViewer() {
       style={{ height: '100vh', overflow: 'auto' }}
       itemLayout="horizontal"
       dataSource={dependencies}
-      renderItem={(projectPath, idx) => (
-        <>
-          <List.Item style={{ display: 'flex', alignItems: 'center', padding: '20px' }}>
-            <List.Item.Meta title={projectPath.name} description={projectPath.version} />
-          </List.Item>
-          <List.Item style={{ backgroundColor: '#fff' }}>
-            <DependencyDetailInfo
-              dependencyName={projectPath.name}
-              dependencyVersion={projectPath.version}
-            />
-          </List.Item>
-        </>
+      renderItem={(projectPath) => (
+        <DependencyItem
+          key={projectPath.name}
+          name={projectPath.name}
+          version={projectPath.version}
+        />
       )}
     />
   )

--- a/renderer/components/dependencies/dependencies-detail-viewer.tsx
+++ b/renderer/components/dependencies/dependencies-detail-viewer.tsx
@@ -2,9 +2,11 @@ import { List } from 'antd'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 import { DependencyItem } from './dependency-item'
+import { DependencyHeader } from './header'
 
 export function DependenciesDetailViewer() {
   const [dependencies, setDependencies] = useState<{ name: string; version: string }[]>([])
+  const [projectPath, setProjectPath] = useState('')
   const router = useRouter()
   const id = router.query.id
 
@@ -20,6 +22,8 @@ export function DependenciesDetailViewer() {
       if (!currentProjectPath) {
         return
       }
+
+      setProjectPath(currentProjectPath.path)
 
       const { data, currentHash } = await window.cacheAPI.getDependencies(currentProjectPath.path)
 
@@ -39,19 +43,20 @@ export function DependenciesDetailViewer() {
   }, [])
 
   return (
-    <List
-      style={{ height: '100vh', overflow: 'auto' }}
-      itemLayout="horizontal"
-      dataSource={dependencies}
-      renderItem={(projectPath) => (
-        <DependencyItem
-          key={projectPath.name}
-          name={projectPath.name}
-          version={projectPath.version}
-        />
-      )}
-    />
+    <>
+      <DependencyHeader title={projectPath} />
+      <List
+        style={{ height: '100vh', overflow: 'auto' }}
+        itemLayout="horizontal"
+        dataSource={dependencies}
+        renderItem={(projectPath) => (
+          <DependencyItem
+            key={projectPath.name}
+            name={projectPath.name}
+            version={projectPath.version}
+          />
+        )}
+      />
+    </>
   )
 }
-
-const getCachedData = () => {}

--- a/renderer/components/dependencies/dependencies-detail-viewer.tsx
+++ b/renderer/components/dependencies/dependencies-detail-viewer.tsx
@@ -1,0 +1,7 @@
+import { useRouter } from 'next/router'
+
+export function DependenciesDetailViewer() {
+  const router = useRouter()
+
+  return <div>{router.query.id}</div>
+}

--- a/renderer/components/dependencies/dependencies-detail-viewer.tsx
+++ b/renderer/components/dependencies/dependencies-detail-viewer.tsx
@@ -38,12 +38,12 @@ export function DependenciesDetailViewer() {
         <>
           <List.Item style={{ display: 'flex', alignItems: 'center', padding: '20px' }}>
             <List.Item.Meta title={projectPath.name} description={projectPath.version} />
-            {idx === 0 ? (
-              <DependencyDetailInfo
-                dependencyName={projectPath.name}
-                dependencyVersion={projectPath.version}
-              />
-            ) : null}
+          </List.Item>
+          <List.Item style={{ backgroundColor: '#fff' }}>
+            <DependencyDetailInfo
+              dependencyName={projectPath.name}
+              dependencyVersion={projectPath.version}
+            />
           </List.Item>
         </>
       )}

--- a/renderer/components/dependencies/dependencies-detail-viewer.tsx
+++ b/renderer/components/dependencies/dependencies-detail-viewer.tsx
@@ -21,9 +21,18 @@ export function DependenciesDetailViewer() {
         return
       }
 
-      const dependencies = await window.projectAPI.getDependencies(currentProjectPath.path)
+      const { data, currentHash } = await window.cacheAPI.getDependencies(currentProjectPath.path)
 
-      setDependencies(dependencies)
+      if (data) {
+        setDependencies(data)
+        return
+      }
+
+      const newDependencies = await window.projectAPI.getDependencies(currentProjectPath.path)
+
+      await window.cacheAPI.setDependencies(currentProjectPath.path, newDependencies, currentHash)
+
+      setDependencies(newDependencies)
     }
 
     fetchAndSetDependencies()
@@ -44,3 +53,5 @@ export function DependenciesDetailViewer() {
     />
   )
 }
+
+const getCachedData = () => {}

--- a/renderer/components/dependencies/dependencies-detail-viewer.tsx
+++ b/renderer/components/dependencies/dependencies-detail-viewer.tsx
@@ -50,6 +50,7 @@ export function DependenciesDetailViewer() {
         style={{ height: '100vh', overflow: 'auto' }}
         itemLayout="horizontal"
         dataSource={dependencies}
+        loading={!dependencies.length}
         renderItem={(projectPath) => (
           <DependencyItem
             key={projectPath.name}
@@ -61,3 +62,7 @@ export function DependenciesDetailViewer() {
     </>
   )
 }
+
+// 로딩 처리
+// projectlist -> 삭제 가능
+// 프로젝트 선택시 중복안되도록, npm repository 아니면 안되도록 처리

--- a/renderer/components/dependencies/dependencies-viewer.tsx
+++ b/renderer/components/dependencies/dependencies-viewer.tsx
@@ -1,11 +1,14 @@
+import { RightOutlined } from '@ant-design/icons'
 import { Button, List } from 'antd'
 import Link from 'next/link'
+import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { v4 as uuidv4 } from 'uuid'
 
 export function DependenciesViewer() {
   const [projectPaths, setProjectPaths] = useState<{ id: string; path: string }[]>([])
+  const router = useRouter()
 
   useEffect(() => {
     const fetchProjectPaths = async () => {
@@ -36,6 +39,10 @@ export function DependenciesViewer() {
     setProjectPaths((prev) => [...prev, newItem])
   }
 
+  const handleClickListItem = (dependencyId: string) => {
+    router.push(`/dependencies/${dependencyId}`)
+  }
+
   return (
     <>
       <Container>
@@ -49,9 +56,10 @@ export function DependenciesViewer() {
         itemLayout="horizontal"
         dataSource={projectPaths}
         renderItem={(projectPath) => (
-          <List.Item style={{ display: 'flex', alignItems: 'center', padding: '20px' }}>
-            <Link href={`/dependencies/${projectPath.id}`}>{projectPath.path}</Link>
-          </List.Item>
+          <StyledListItem onClick={() => handleClickListItem(projectPath.id)}>
+            {projectPath.path}
+            <RightOutlined />
+          </StyledListItem>
         )}
       />
     </>
@@ -68,4 +76,16 @@ const Container = styled.div`
   padding: 15px;
   background-color: #fff;
   align-items: center;
+`
+
+const StyledListItem = styled(List.Item)`
+  display: flex !important;
+  align-items: center !important;
+  padding: 20px !important;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #f0f0f0;
+    color: #1890ff;
+  }
 `

--- a/renderer/components/dependencies/dependencies-viewer.tsx
+++ b/renderer/components/dependencies/dependencies-viewer.tsx
@@ -46,11 +46,14 @@ export function DependenciesViewer() {
 
   return (
     <>
-      <DependencyHeader title="Project List">
-        <Button type="primary" onClick={handleAddProject} style={{ marginLeft: 'auto' }}>
-          Add Project
-        </Button>
-      </DependencyHeader>
+      <DependencyHeader
+        title="Project List"
+        right={
+          <Button type="primary" onClick={handleAddProject} style={{ marginLeft: 'auto' }}>
+            Add Project
+          </Button>
+        }
+      ></DependencyHeader>
       <List
         style={{ height: '100vh', overflow: 'auto' }}
         itemLayout="horizontal"

--- a/renderer/components/dependencies/dependencies-viewer.tsx
+++ b/renderer/components/dependencies/dependencies-viewer.tsx
@@ -35,6 +35,10 @@ export function DependenciesViewer() {
         return
       }
 
+      if (prevProjectPath && prevProjectPath.some((path) => path.path === projectPath.path)) {
+        throw new Error('이미 등록된 repository입니다.')
+      }
+
       const newItem = { id: uuidv4(), path: projectPath.path }
 
       if (!prevProjectPath || prevProjectPath.length === 0) {

--- a/renderer/components/dependencies/dependencies-viewer.tsx
+++ b/renderer/components/dependencies/dependencies-viewer.tsx
@@ -1,14 +1,15 @@
 import { RightOutlined } from '@ant-design/icons'
-import { Button, List } from 'antd'
+import { Button, Checkbox, CheckboxChangeEvent, List } from 'antd'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { useEffect, useState } from 'react'
+import { ChangeEvent, useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { v4 as uuidv4 } from 'uuid'
 import { DependencyHeader } from './header'
 
 export function DependenciesViewer() {
   const [projectPaths, setProjectPaths] = useState<{ id: string; path: string }[]>([])
+  const [checkedIdList, setCheckedIdList] = useState<string[]>([])
   const router = useRouter()
 
   useEffect(() => {
@@ -40,6 +41,29 @@ export function DependenciesViewer() {
     setProjectPaths((prev) => [...prev, newItem])
   }
 
+  const handleDeleteProject = async () => {
+    console.log(checkedIdList)
+    const newProjectPaths = projectPaths.filter(
+      (projectPath) => !checkedIdList.includes(projectPath.id)
+    )
+
+    await window.storeAPI.set('projectPath', newProjectPaths)
+
+    setProjectPaths(newProjectPaths)
+    setCheckedIdList([])
+  }
+
+  const handleChangeCheckBox = (e: CheckboxChangeEvent, checkedid: string) => {
+    const { checked } = e.target
+
+    if (checked) {
+      setCheckedIdList((prev) => [...prev, checkedid])
+      return
+    }
+
+    setCheckedIdList((prev) => prev.filter((id) => id !== checkedid))
+  }
+
   const handleClickListItem = (dependencyId: string) => {
     router.push(`/dependencies/${dependencyId}`)
   }
@@ -49,9 +73,19 @@ export function DependenciesViewer() {
       <DependencyHeader
         title="Project List"
         right={
-          <Button type="primary" onClick={handleAddProject} style={{ marginLeft: 'auto' }}>
-            Add Project
-          </Button>
+          <>
+            <Button type="primary" onClick={handleAddProject} style={{ marginLeft: 'auto' }}>
+              Add Project
+            </Button>
+            <Button
+              onClick={handleDeleteProject}
+              type="primary"
+              danger
+              style={{ marginLeft: '10px' }}
+            >
+              Delete Project
+            </Button>
+          </>
         }
       ></DependencyHeader>
       <List
@@ -59,9 +93,11 @@ export function DependenciesViewer() {
         itemLayout="horizontal"
         dataSource={projectPaths}
         renderItem={(projectPath) => (
-          <StyledListItem onClick={() => handleClickListItem(projectPath.id)}>
-            {projectPath.path}
-            <RightOutlined />
+          <StyledListItem>
+            <Checkbox onChange={(e) => handleChangeCheckBox(e, projectPath.id)}>
+              {projectPath.path}
+            </Checkbox>
+            <RightOutlined onClick={() => handleClickListItem(projectPath.id)} />
           </StyledListItem>
         )}
       />

--- a/renderer/components/dependencies/dependencies-viewer.tsx
+++ b/renderer/components/dependencies/dependencies-viewer.tsx
@@ -22,27 +22,34 @@ export function DependenciesViewer() {
   }, [])
 
   const handleAddProject = async () => {
-    const projectPath = await window.projectAPI.getProject()
+    try {
+      const projectPath = await window.projectAPI.getProject()
 
-    const prevProjectPath = await window.storeAPI.get('projectPath')
+      if (projectPath.error) {
+        throw new Error(projectPath.error)
+      }
 
-    if (!projectPath) {
-      return
+      const prevProjectPath = await window.storeAPI.get('projectPath')
+
+      if (!projectPath.path) {
+        return
+      }
+
+      const newItem = { id: uuidv4(), path: projectPath.path }
+
+      if (!prevProjectPath || prevProjectPath.length === 0) {
+        await window.storeAPI.set('projectPath', [newItem])
+      } else {
+        window.storeAPI.set('projectPath', [...prevProjectPath, newItem])
+      }
+
+      setProjectPaths((prev) => [...prev, newItem])
+    } catch (err) {
+      alert(err.message)
     }
-
-    const newItem = { id: uuidv4(), path: projectPath }
-
-    if (!prevProjectPath || prevProjectPath.length === 0) {
-      await window.storeAPI.set('projectPath', [newItem])
-    } else {
-      window.storeAPI.set('projectPath', [...prevProjectPath, newItem])
-    }
-
-    setProjectPaths((prev) => [...prev, newItem])
   }
 
   const handleDeleteProject = async () => {
-    console.log(checkedIdList)
     const newProjectPaths = projectPaths.filter(
       (projectPath) => !checkedIdList.includes(projectPath.id)
     )
@@ -65,7 +72,7 @@ export function DependenciesViewer() {
   }
 
   const handleClickListItem = (dependencyId: string) => {
-    router.push(`/dependencies/${dependencyId}`)
+    router.push(`/dependencies/${dependencyId}`, undefined, { shallow: true })
   }
 
   return (

--- a/renderer/components/dependencies/dependencies-viewer.tsx
+++ b/renderer/components/dependencies/dependencies-viewer.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { v4 as uuidv4 } from 'uuid'
+import { DependencyHeader } from './header'
 
 export function DependenciesViewer() {
   const [projectPaths, setProjectPaths] = useState<{ id: string; path: string }[]>([])
@@ -45,12 +46,11 @@ export function DependenciesViewer() {
 
   return (
     <>
-      <Container>
-        <Text>Project List</Text>
-        <Button onClick={handleAddProject} style={{ marginLeft: 'auto' }}>
-          Add Project Path
+      <DependencyHeader title="Project List">
+        <Button type="primary" onClick={handleAddProject} style={{ marginLeft: 'auto' }}>
+          Add Project
         </Button>
-      </Container>
+      </DependencyHeader>
       <List
         style={{ height: '100vh', overflow: 'auto' }}
         itemLayout="horizontal"
@@ -65,18 +65,6 @@ export function DependenciesViewer() {
     </>
   )
 }
-
-const Text = styled.h1`
-  font-size: 14px;
-  font-weight: 700;
-`
-
-const Container = styled.div`
-  display: flex;
-  padding: 15px;
-  background-color: #fff;
-  align-items: center;
-`
 
 const StyledListItem = styled(List.Item)`
   display: flex !important;

--- a/renderer/components/dependencies/dependencies-viewer.tsx
+++ b/renderer/components/dependencies/dependencies-viewer.tsx
@@ -1,9 +1,11 @@
 import { Button, List } from 'antd'
+import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import styled from 'styled-components'
+import { v4 as uuidv4 } from 'uuid'
 
 export function DependenciesViewer() {
-  const [projectPaths, setProjectPaths] = useState<string[]>([])
+  const [projectPaths, setProjectPaths] = useState<{ id: string; path: string }[]>([])
 
   useEffect(() => {
     const fetchProjectPaths = async () => {
@@ -23,13 +25,15 @@ export function DependenciesViewer() {
       return
     }
 
+    const newItem = { id: uuidv4(), path: projectPath }
+
     if (!prevProjectPath || prevProjectPath.length === 0) {
-      await window.storeAPI.set('projectPath', [projectPath])
+      await window.storeAPI.set('projectPath', [newItem])
     } else {
-      window.storeAPI.set('projectPath', [...prevProjectPath, projectPath])
+      window.storeAPI.set('projectPath', [...prevProjectPath, newItem])
     }
 
-    setProjectPaths((prev) => [...prev, projectPath])
+    setProjectPaths((prev) => [...prev, newItem])
   }
 
   return (
@@ -46,7 +50,7 @@ export function DependenciesViewer() {
         dataSource={projectPaths}
         renderItem={(projectPath) => (
           <List.Item style={{ display: 'flex', alignItems: 'center', padding: '20px' }}>
-            {projectPath}
+            <Link href={`/dependencies/${projectPath.id}`}>{projectPath.path}</Link>
           </List.Item>
         )}
       />

--- a/renderer/components/dependencies/dependencies-viewer.tsx
+++ b/renderer/components/dependencies/dependencies-viewer.tsx
@@ -1,0 +1,67 @@
+import { Button, List } from 'antd'
+import { useEffect, useState } from 'react'
+import styled from 'styled-components'
+
+export function DependenciesViewer() {
+  const [projectPaths, setProjectPaths] = useState<string[]>([])
+
+  useEffect(() => {
+    const fetchProjectPaths = async () => {
+      const projectPaths = await window.storeAPI.get('projectPath')
+      setProjectPaths(projectPaths || [])
+    }
+
+    fetchProjectPaths()
+  }, [])
+
+  const handleAddProject = async () => {
+    const projectPath = await window.projectAPI.getProject()
+
+    const prevProjectPath = await window.storeAPI.get('projectPath')
+
+    if (!projectPath) {
+      return
+    }
+
+    if (!prevProjectPath || prevProjectPath.length === 0) {
+      await window.storeAPI.set('projectPath', [projectPath])
+    } else {
+      window.storeAPI.set('projectPath', [...prevProjectPath, projectPath])
+    }
+
+    setProjectPaths((prev) => [...prev, projectPath])
+  }
+
+  return (
+    <>
+      <Container>
+        <Text>Project List</Text>
+        <Button onClick={handleAddProject} style={{ marginLeft: 'auto' }}>
+          Add Project Path
+        </Button>
+      </Container>
+      <List
+        style={{ height: '100vh', overflow: 'auto' }}
+        itemLayout="horizontal"
+        dataSource={projectPaths}
+        renderItem={(projectPath) => (
+          <List.Item style={{ display: 'flex', alignItems: 'center', padding: '20px' }}>
+            {projectPath}
+          </List.Item>
+        )}
+      />
+    </>
+  )
+}
+
+const Text = styled.h1`
+  font-size: 14px;
+  font-weight: 700;
+`
+
+const Container = styled.div`
+  display: flex;
+  padding: 15px;
+  background-color: #fff;
+  align-items: center;
+`

--- a/renderer/components/dependencies/dependency-detail-info.tsx
+++ b/renderer/components/dependencies/dependency-detail-info.tsx
@@ -51,7 +51,7 @@ export function DependencyDetailInfo({
   }, [])
 
   if (!currentDependencyInfo || !latestDependencyInfo) {
-    return <div>Loading...</div>
+    return <Container>Loading...</Container>
   }
 
   const columns = [
@@ -77,13 +77,13 @@ export function DependencyDetailInfo({
       key: '1',
       type: 'Current',
       description: currentDependencyInfo.version,
-      unpackedSize: currentDependencyInfo.unpackedSize,
+      unpackedSize: bytoToKb(currentDependencyInfo.unpackedSize),
     },
     {
       key: '2',
       type: 'Latest',
       description: latestDependencyInfo.version,
-      unpackedSize: latestDependencyInfo.unpackedSize,
+      unpackedSize: bytoToKb(latestDependencyInfo.unpackedSize),
     },
   ]
 
@@ -123,3 +123,7 @@ const Title = styled.h1`
 const Description = styled.p`
   color: rgba(0, 0, 0, 0.45);
 `
+
+const bytoToKb = (bytes: number) => {
+  return (bytes / 1024).toFixed(2) + ' KB'
+}

--- a/renderer/components/dependencies/dependency-detail-info.tsx
+++ b/renderer/components/dependencies/dependency-detail-info.tsx
@@ -50,6 +50,10 @@ export function DependencyDetailInfo({
     fetchLatestDependencyInfo()
   }, [])
 
+  const handleClickLinkToDocs = () => {
+    window.projectAPI.linkToDocs(dependencyName)
+  }
+
   if (!currentDependencyInfo || !latestDependencyInfo) {
     return <Container>Loading...</Container>
   }
@@ -99,7 +103,11 @@ export function DependencyDetailInfo({
         pagination={false}
       />
 
-      <Button style={{ width: '80%', margin: '15px auto 0 auto' }} variant="filled">
+      <Button
+        style={{ width: '80%', margin: '15px auto 0 auto' }}
+        variant="filled"
+        onClick={handleClickLinkToDocs}
+      >
         Link to Docs
       </Button>
     </Container>

--- a/renderer/components/dependencies/dependency-detail-info.tsx
+++ b/renderer/components/dependencies/dependency-detail-info.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import styled from 'styled-components'
-import { Button, Table } from 'antd'
+import { Button, Spin, Table } from 'antd'
 
 interface DependencyDetailInfoProps {
   dependencyName: string
@@ -20,42 +20,59 @@ export function DependencyDetailInfo({
 }: DependencyDetailInfoProps) {
   const [currentDependencyInfo, setCurrentDependencyInfo] = useState<DependencyInfo | null>(null)
   const [latestDependencyInfo, setLatestDependencyInfo] = useState<DependencyInfo | null>(null)
+  const [error, setError] = useState<Error | null>(null)
 
   useEffect(() => {
-    async function fetchCurrentDependencyInfo() {
-      const dependency = await window.projectAPI.getPackageInfo(
-        `${dependencyName}@${dependencyVersion}`
-      )
-
-      setCurrentDependencyInfo({
-        name: dependency.name,
-        version: dependency.version,
-        description: dependency.description,
-        unpackedSize: dependency['dist.unpackedSize'],
-      })
+    function fetchCurrentDependencyInfo() {
+      window.projectAPI
+        .getPackageInfo(`${dependencyName}@${dependencyVersion}`)
+        .then((dependency) => {
+          setCurrentDependencyInfo({
+            name: dependency.name,
+            version: dependency.version,
+            description: dependency.description,
+            unpackedSize: dependency['dist.unpackedSize'],
+          })
+        })
+        .catch((e) => {
+          setError(e)
+        })
     }
 
-    async function fetchLatestDependencyInfo() {
-      const latestDependency = await window.projectAPI.getPackageInfo(dependencyName)
-
-      setLatestDependencyInfo({
-        name: latestDependency.name,
-        version: latestDependency.version,
-        description: latestDependency.description,
-        unpackedSize: latestDependency['dist.unpackedSize'],
-      })
+    function fetchLatestDependencyInfo() {
+      window.projectAPI
+        .getPackageInfo(dependencyName)
+        .then((dependency) => {
+          setLatestDependencyInfo({
+            name: dependency.name,
+            version: dependency.version,
+            description: dependency.description,
+            unpackedSize: dependency['dist.unpackedSize'],
+          })
+        })
+        .catch((e) => {
+          setError(e)
+        })
     }
 
     fetchCurrentDependencyInfo()
     fetchLatestDependencyInfo()
-  }, [])
+  }, [dependencyName, dependencyVersion])
 
   const handleClickLinkToDocs = () => {
     window.projectAPI.linkToDocs(dependencyName)
   }
 
+  if (error) {
+    return <Container style={{ color: '#ff7875' }}>인증 에러 발생</Container>
+  }
+
   if (!currentDependencyInfo || !latestDependencyInfo) {
-    return <Container>Loading...</Container>
+    return (
+      <Container>
+        <Spin />
+      </Container>
+    )
   }
 
   const columns = [

--- a/renderer/components/dependencies/dependency-detail-info.tsx
+++ b/renderer/components/dependencies/dependency-detail-info.tsx
@@ -149,6 +149,10 @@ const Description = styled.p`
   color: rgba(0, 0, 0, 0.45);
 `
 
-const bytoToKb = (bytes: number) => {
+const bytoToKb = (bytes?: number) => {
+  if (!bytes) {
+    return 'UNKNOWN'
+  }
+
   return (bytes / 1024).toFixed(2) + ' KB'
 }

--- a/renderer/components/dependencies/dependency-detail-info.tsx
+++ b/renderer/components/dependencies/dependency-detail-info.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react'
+import styled from 'styled-components'
+import { Button, Table } from 'antd'
 
 interface DependencyDetailInfoProps {
   dependencyName: string
@@ -46,32 +48,78 @@ export function DependencyDetailInfo({
 
     fetchCurrentDependencyInfo()
     fetchLatestDependencyInfo()
-
-    // name, version으로 조회
-    // description
-    // 제일 최신버전, 제일 최신버전의 unpackedSize
-    // 간단 한줄 설명 -> description
-    // dist.unpackedSize
-    // npm docs로 보여주기
-  })
+  }, [])
 
   if (!currentDependencyInfo || !latestDependencyInfo) {
     return <div>Loading...</div>
   }
 
+  const columns = [
+    {
+      title: 'Type',
+      dataIndex: 'type',
+      key: 'type',
+    },
+    {
+      title: 'Description',
+      dataIndex: 'description',
+      key: 'description',
+    },
+    {
+      title: 'Unpacked Size',
+      dataIndex: 'unpackedSize',
+      key: 'unpackedSize',
+    },
+  ]
+
+  const dataSource = [
+    {
+      key: '1',
+      type: 'Current',
+      description: currentDependencyInfo.version,
+      unpackedSize: currentDependencyInfo.unpackedSize,
+    },
+    {
+      key: '2',
+      type: 'Latest',
+      description: latestDependencyInfo.version,
+      unpackedSize: latestDependencyInfo.unpackedSize,
+    },
+  ]
+
   return (
-    <div>
-      <h1>{currentDependencyInfo.name}</h1>
-      <h2>{currentDependencyInfo.version}</h2>
-      <p>{currentDependencyInfo.description}</p>
-      <p>{currentDependencyInfo.unpackedSize}</p>
+    <Container>
+      <Title>{currentDependencyInfo.name}</Title>
+      <Description>{currentDependencyInfo.description}</Description>
 
-      <h2>Latest</h2>
+      <Table
+        columns={columns}
+        dataSource={dataSource}
+        style={{ marginTop: '15px' }}
+        pagination={false}
+      />
 
-      <h1>{latestDependencyInfo.name}</h1>
-      <h2>{latestDependencyInfo.version}</h2>
-      <p>{latestDependencyInfo.description}</p>
-      <p>{latestDependencyInfo.unpackedSize}</p>
-    </div>
+      <Button style={{ width: '80%', margin: '15px auto 0 auto' }} variant="filled">
+        Link to Docs
+      </Button>
+    </Container>
   )
 }
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 10px 20px;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+`
+
+const Title = styled.h1`
+  font-size: 24px;
+  font-weight: 700;
+`
+
+const Description = styled.p`
+  color: rgba(0, 0, 0, 0.45);
+`

--- a/renderer/components/dependencies/dependency-detail-info.tsx
+++ b/renderer/components/dependencies/dependency-detail-info.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react'
+
+interface DependencyDetailInfoProps {
+  dependencyName: string
+  dependencyVersion: string
+}
+
+interface DependencyInfo {
+  name: string
+  version: string
+  description: string
+  unpackedSize: number
+}
+
+export function DependencyDetailInfo({
+  dependencyName,
+  dependencyVersion,
+}: DependencyDetailInfoProps) {
+  const [currentDependencyInfo, setCurrentDependencyInfo] = useState<DependencyInfo | null>(null)
+  const [latestDependencyInfo, setLatestDependencyInfo] = useState<DependencyInfo | null>(null)
+
+  useEffect(() => {
+    async function fetchCurrentDependencyInfo() {
+      const dependency = await window.projectAPI.getPackageInfo(
+        `${dependencyName}@${dependencyVersion}`
+      )
+
+      setCurrentDependencyInfo({
+        name: dependency.name,
+        version: dependency.version,
+        description: dependency.description,
+        unpackedSize: dependency['dist.unpackedSize'],
+      })
+    }
+
+    async function fetchLatestDependencyInfo() {
+      const latestDependency = await window.projectAPI.getPackageInfo(dependencyName)
+
+      setLatestDependencyInfo({
+        name: latestDependency.name,
+        version: latestDependency.version,
+        description: latestDependency.description,
+        unpackedSize: latestDependency['dist.unpackedSize'],
+      })
+    }
+
+    fetchCurrentDependencyInfo()
+    fetchLatestDependencyInfo()
+
+    // name, version으로 조회
+    // description
+    // 제일 최신버전, 제일 최신버전의 unpackedSize
+    // 간단 한줄 설명 -> description
+    // dist.unpackedSize
+    // npm docs로 보여주기
+  })
+
+  if (!currentDependencyInfo || !latestDependencyInfo) {
+    return <div>Loading...</div>
+  }
+
+  return (
+    <div>
+      <h1>{currentDependencyInfo.name}</h1>
+      <h2>{currentDependencyInfo.version}</h2>
+      <p>{currentDependencyInfo.description}</p>
+      <p>{currentDependencyInfo.unpackedSize}</p>
+
+      <h2>Latest</h2>
+
+      <h1>{latestDependencyInfo.name}</h1>
+      <h2>{latestDependencyInfo.version}</h2>
+      <p>{latestDependencyInfo.description}</p>
+      <p>{latestDependencyInfo.unpackedSize}</p>
+    </div>
+  )
+}

--- a/renderer/components/dependencies/dependency-item.tsx
+++ b/renderer/components/dependencies/dependency-item.tsx
@@ -2,6 +2,7 @@ import { List } from 'antd'
 import { DependencyDetailInfo } from './dependency-detail-info'
 import { useState } from 'react'
 import { UpOutlined, DownOutlined } from '@ant-design/icons'
+import { ErrorBoundary } from 'react-error-boundary'
 
 interface DependencyItemProps {
   name: string

--- a/renderer/components/dependencies/dependency-item.tsx
+++ b/renderer/components/dependencies/dependency-item.tsx
@@ -1,0 +1,34 @@
+import { List } from 'antd'
+import { DependencyDetailInfo } from './dependency-detail-info'
+import { useState } from 'react'
+import { UpOutlined, DownOutlined } from '@ant-design/icons'
+
+interface DependencyItemProps {
+  name: string
+  version: string
+}
+
+export function DependencyItem({ name, version }: DependencyItemProps) {
+  const [openDetail, setOpenDetail] = useState(false)
+
+  const handleClickListItem = () => {
+    setOpenDetail((prev) => !prev)
+  }
+
+  return (
+    <>
+      <List.Item
+        style={{ display: 'flex', alignItems: 'center', padding: '20px', cursor: 'pointer' }}
+        onClick={handleClickListItem}
+      >
+        <List.Item.Meta title={name} description={version} />
+        {openDetail ? <UpOutlined /> : <DownOutlined />}
+      </List.Item>
+      {openDetail ? (
+        <List.Item style={{ backgroundColor: '#fff' }}>
+          <DependencyDetailInfo dependencyName={name} dependencyVersion={version} />
+        </List.Item>
+      ) : null}
+    </>
+  )
+}

--- a/renderer/components/dependencies/dependency-item.tsx
+++ b/renderer/components/dependencies/dependency-item.tsx
@@ -2,7 +2,6 @@ import { List } from 'antd'
 import { DependencyDetailInfo } from './dependency-detail-info'
 import { useState } from 'react'
 import { UpOutlined, DownOutlined } from '@ant-design/icons'
-import { ErrorBoundary } from 'react-error-boundary'
 
 interface DependencyItemProps {
   name: string

--- a/renderer/components/dependencies/header.tsx
+++ b/renderer/components/dependencies/header.tsx
@@ -1,15 +1,17 @@
 import styled from 'styled-components'
 
 interface DependencyHeaderProps {
+  left?: React.ReactNode
   title: string
-  children?: React.ReactNode
+  right?: React.ReactNode
 }
 
-export function DependencyHeader({ title, children }: DependencyHeaderProps) {
+export function DependencyHeader({ title, right, left }: DependencyHeaderProps) {
   return (
     <Container>
+      {left}
       <Text>{title}</Text>
-      {children}
+      {right}
     </Container>
   )
 }

--- a/renderer/components/dependencies/header.tsx
+++ b/renderer/components/dependencies/header.tsx
@@ -1,0 +1,27 @@
+import styled from 'styled-components'
+
+interface DependencyHeaderProps {
+  title: string
+  children?: React.ReactNode
+}
+
+export function DependencyHeader({ title, children }: DependencyHeaderProps) {
+  return (
+    <Container>
+      <Text>{title}</Text>
+      {children}
+    </Container>
+  )
+}
+
+const Text = styled.h1`
+  font-size: 14px;
+  font-weight: 700;
+`
+
+const Container = styled.div`
+  display: flex;
+  padding: 15px;
+  background-color: #fff;
+  align-items: center;
+`

--- a/renderer/components/shared/back-button.tsx
+++ b/renderer/components/shared/back-button.tsx
@@ -1,0 +1,12 @@
+import { LeftOutlined } from '@ant-design/icons'
+import { useRouter } from 'next/router'
+
+export function BackButton() {
+  const router = useRouter()
+
+  const handleClickBackButton = () => {
+    router.back()
+  }
+
+  return <LeftOutlined onClick={handleClickBackButton} style={{ marginRight: '20px' }} />
+}

--- a/renderer/constants.ts
+++ b/renderer/constants.ts
@@ -9,4 +9,9 @@ export const SIDE_MENU = [
     label: 'node version manager',
     href: '/nvm',
   },
+  {
+    key: 'dependencies',
+    label: 'dependencies',
+    href: '/dependencies',
+  },
 ]

--- a/renderer/next.config.js
+++ b/renderer/next.config.js
@@ -1,5 +1,7 @@
 /** @type {import('next').NextConfig} */
-module.exports = {
+const withTm = require('next-transpile-modules')
+
+const nextConfig = {
   output: 'export',
   distDir: process.env.NODE_ENV === 'production' ? '../app' : '.next',
   compiler: {
@@ -15,3 +17,5 @@ module.exports = {
     return config
   },
 }
+
+module.exports = withTm(['antd', '@ant-design/icons'])(nextConfig)

--- a/renderer/pages/dependencies.tsx
+++ b/renderer/pages/dependencies.tsx
@@ -1,0 +1,5 @@
+import { DependenciesViewer } from '../components/dependencies/dependencies-viewer'
+
+export default function NvmPage() {
+  return <DependenciesViewer />
+}

--- a/renderer/pages/dependencies.tsx
+++ b/renderer/pages/dependencies.tsx
@@ -1,5 +1,0 @@
-import { DependenciesViewer } from '../components/dependencies/dependencies-viewer'
-
-export default function NvmPage() {
-  return <DependenciesViewer />
-}

--- a/renderer/pages/dependencies/[id].tsx
+++ b/renderer/pages/dependencies/[id].tsx
@@ -1,0 +1,5 @@
+import { DependenciesDetailViewer } from '../../components/dependencies/dependencies-detail-viewer'
+
+export default function DependenciesDetailPage() {
+  return <DependenciesDetailViewer />
+}

--- a/renderer/pages/dependencies/index.tsx
+++ b/renderer/pages/dependencies/index.tsx
@@ -1,0 +1,5 @@
+import { DependenciesViewer } from '../../components/dependencies/dependencies-viewer'
+
+export default function DependenciesPage() {
+  return <DependenciesViewer />
+}

--- a/renderer/preload.d.ts
+++ b/renderer/preload.d.ts
@@ -1,5 +1,6 @@
 import {
   ApiHandler,
+  CacheHandler,
   IpcHandler,
   NpmrcHandler,
   NvmHandler,
@@ -16,5 +17,6 @@ declare global {
     terminalAPI: TerminalHandler
     projectAPI: ProjectHandler
     storeAPI: StoreHandler
+    cacheAPI: CacheHandler
   }
 }

--- a/renderer/preload.d.ts
+++ b/renderer/preload.d.ts
@@ -1,4 +1,12 @@
-import { ApiHandler, IpcHandler, NpmrcHandler, NvmHandler, TerminalHandler } from '../main/preload'
+import {
+  ApiHandler,
+  IpcHandler,
+  NpmrcHandler,
+  NvmHandler,
+  ProjectHandler,
+  StoreHandler,
+  TerminalHandler,
+} from '../main/preload'
 
 declare global {
   interface Window {
@@ -6,5 +14,7 @@ declare global {
     api: ApiHandler
     nvmAPI: NvmHandler
     terminalAPI: TerminalHandler
+    projectAPI: ProjectHandler
+    storeAPI: StoreHandler
   }
 }


### PR DESCRIPTION
## 설명

dependency 페이지를 추가합니다.

- project를 등록 할 수 있는 기능을 추가합니다.
  - 중복된 프로젝트인 경우에는 등록이 안되도록 합니다.
  - package.json이 없는 repository 같은 경우에는 등록되지 않도록 합니다.
  - eletron-store를 통해 프로젝트를 저장합니다.
- project를 클릭하여 project내에 있는 dependecy들을 확인할 수 있습니다.
  - `npm list --json`을 통해 dependency들을 조회합니다.
  - cache를 통해 dependency 조회속도를 향상시키고, lockFile이 변경될시 cache busting이 되도록 합니다.
 - 특정 dependency를 클릭할 시 dependency에 대한 detail을 보여줍니다.
   - 현재 버전, 최신 버전을 보여주고 각각의 `unpackedSize`를 보여줍니다.
   - link-to-docs 버튼을 클릭시 `npm docs <packagename>`을 통하여 실제 문서로 이동합니다. 

## 스크린샷

![화면 기록 2025-01-19 오후 11 34 16](https://github.com/user-attachments/assets/66d1a17b-2b55-4ad3-8fb0-8b6bfeea8a24)


